### PR TITLE
Add: show dialog before leaving the page

### DIFF
--- a/oozappa/templates/jobset.html
+++ b/oozappa/templates/jobset.html
@@ -2,7 +2,14 @@
 
 {% block title %}Oozappa - Jobset : {{ jobset.title }}{% endblock %}
 
-{% block headline %}Jobset {{ jobset.title }}{% endblock %}
+{% block headline %}
+  Jobset {{ jobset.title }}
+  <script type="text/javascript">
+    window.onbeforeunload = function() {
+      return 'Do not close while running the jobset.';
+    }
+  </script>
+{% endblock %}
 
 {% block body %}
 <div>


### PR DESCRIPTION
Show dialog before leaving the page. (only jobset.html)

reference
http://stackoverflow.com/questions/276660/how-can-i-override-the-onbeforeunload-dialog-and-replace-it-with-my-own

IE11 with Windows8
![ie11_win8](https://cloud.githubusercontent.com/assets/831702/9039016/7517c798-3a33-11e5-9393-ed921df5091f.png)

Chrome (version 44)
![chrome44](https://cloud.githubusercontent.com/assets/831702/9039017/751b81da-3a33-11e5-90ee-803ba6919691.png)

Firefox (version 38)
![firefox38](https://cloud.githubusercontent.com/assets/831702/9039018/7522b14e-3a33-11e5-9536-71a0672203d4.png)


