### PR TITLE
always add sqlite prefix.

### DIFF
--- a/oozappa/zappa.py
+++ b/oozappa/zappa.py
@@ -44,7 +44,7 @@ def _create_database_path(sqlite_stored_path):
             sqlite_stored_path = os.path.join(os.path.abspath(os.path.curdir), sqlite_stored_path)
         sqlite_stored_path = os.path.abspath(sqlite_stored_path)
         _ensure_directory(sqlite_stored_path)
-        sqlite_stored_path = 'sqlite:///{0}'.format(sqlite_stored_path)
+    sqlite_stored_path = 'sqlite:///{0}'.format(sqlite_stored_path)
     return sqlite_stored_path
 
 


### PR DESCRIPTION
`zappa init` default generated path is 

```
# common/vars.py
  :
settings = _(
        # OOZAPPA_DB: specify sqlite database stored file path.
        OOZAPPA_DB = '/tmp/oozappa/data.sqlite',
  :
```

but, it is invalid as the path of SQLite3(valid path `sqlite:///...` )

This PR is `sqlite:///` prefix  to add default case and user input.